### PR TITLE
Configure Nginx CORS

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -19,9 +19,10 @@ server {
             break;
         }
 
-	# allow the CSSS API to be accessed from any origin
 	proxy_hide_header Access-Control-Allow-Origin;
-	add_header Access-Control-Allow-Origin * always;
+	# replace $http_origin with new.sfucsss.org or sfucsss.org
+	add_header Access-Control-Allow-Origin $http_origin always;
+	add_header Access-Control-Allow-Credentials true;
     }
 
     server_name api.sfucsss.org;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -20,8 +20,8 @@ server {
         }
 
 	proxy_hide_header Access-Control-Allow-Origin;
-	# replace $http_origin with new.sfucsss.org or sfucsss.org
-	add_header Access-Control-Allow-Origin $http_origin always;
+	proxy_hide_header Access-Control-Allow-Credentials;
+	add_header Access-Control-Allow-Origin https://new.sfucsss.org always;
 	add_header Access-Control-Allow-Credentials true;
     }
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -18,6 +18,10 @@ server {
             proxy_pass http://backend;
             break;
         }
+
+	# allow the CSSS API to be accessed from any origin
+	proxy_hide_header Access-Control-Allow-Origin;
+	add_header Access-Control-Allow-Origin * always;
     }
 
     server_name api.sfucsss.org;


### PR DESCRIPTION
I'm going to manually deploy these changes to nginx as I'm doing some testing with the CSSS auth API, but this should, in theory, make configuring CORS for the CSSS API super easy.

In the future we should probably replace '*' with just sfucsss.org, but for now * is good for testing

Update:

Local devs won't even be able to get CORS to work with localhost (i think cors policy needs HTTPS / an actual hostname that isnt localhost to send cookie credentials) so I went ahead and restricted it to new.sfucsss.org. Currently deployed & working :)