### PR TITLE
Github API interface with csss-site-backend

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -2,6 +2,7 @@ import os
 
 root_ip_address = "http://localhost:8000" if os.environ.get("LOCAL") == "true" else "https://api.sfucsss.org"
 guild_id = "1260652618875797504" if os.environ.get("LOCAL") == "true" else "228761314644852736"
+github_org_name = "CSSS-Test-Organization" if os.environ.get("LOCAL") == "true" else "CSSS"
 
 SESSION_ID_LEN = 512
 # technically a max of 8 digits https://www.sfu.ca/computing/about/support/tips/sfu-userid.html

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -24,6 +24,10 @@ async def _github_request_get(
             "X-GitHub-Api-Version": "2022-11-28"
         }
     )
+    rate_limit_remaining = int(result.headers["x-ratelimit-remaining"])
+    if(rate_limit_remaining) < 50:
+        raise Exception("Less than 50 api calls remaining before being rate limited, please try again later")
+    
     return result
 
 async def _github_request_post(
@@ -40,6 +44,27 @@ async def _github_request_post(
         },
         data=post_data
     )
+    rate_limit_remaining = int(result.headers["x-ratelimit-remaining"])
+    if(rate_limit_remaining) < 50:
+        raise Exception("Less than 50 api calls remaining before being rate limited, please try again later")
+
+    return result
+
+async def _github_request_delete(
+        url: str,
+        token: str
+) -> Response:
+    result = requests.delete(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28"}
+    )
+    rate_limit_remaining = int(result.headers["x-ratelimit-remaining"])
+    if(rate_limit_remaining) < 50:
+        raise Exception("Less than 50 api calls remaining before being rate limited, please try again later")
+
     return result
 
 async def get_user_by_username(

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -124,19 +124,21 @@ async def get_user_by_id(
 
 async def add_user_to_org(
         org: str = github_org_name,
+        # We need one of either uid or email. We'll fail if we're provided both.
         uid: str | None = None,
         email: str | None = None
 ) -> None:
+    result = None
     if uid is None and email is None:
         raise ValueError("uid and username cannot both be empty")
-    result = None
+    elif uid is not None and email is not None:
+        raise ValueError("cannot populate both uid and email")
     # Arbitrarily prefer uid
-    if uid is not None and email is None:
+    elif uid is not None:
         result = await _github_request_post(f"https://api.github.com/orgs/{org}/invitations",
                                os.environ.get("GITHUB_TOKEN"),
                                dumps({"invitee_id":uid, "role":"direct_member"}))
-    # Assume at this point both exist, but use email
-    else:
+    elif email is not None:
         result = await _github_request_post(f"https://api.github.com/orgs/{org}/invitations",
                                os.environ.get("GITHUB_TOKEN"),
                                dumps({"email":email, "role":"direct_member"}))

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -70,6 +70,11 @@ async def _github_request_delete(
 async def get_user_by_username(
         username: str
 ) -> GithubUser:
+    """
+        Takes in a Github username and returns an instance of GithubUser.
+
+        May return an empty list if no such user was found.
+    """
     result = await _github_request_get(f"https://api.github.com/users/{username}",
                               os.environ.get("GITHUB_TOKEN"))
     result_json = result.json()
@@ -78,6 +83,11 @@ async def get_user_by_username(
 async def get_user_by_id(
     id: str    
 ) -> int:
+    """
+        Takes in a Github user id and returns an instance of GithubUser.
+
+        May return an empty list if no such user was found.
+    """
     result = await _github_request_get(f"https://api.github.com/user/{id}",
                               os.environ.get("GITHUB_TOKEN"))
     result_json = result.json()
@@ -103,5 +113,18 @@ async def add_user_to_org(
                                dumps({"email":email, "role":"direct_member"}))
     result_json = result.json()
     # Logging here potentially?
-    if(result_json["status"] == "422"):
-        raise Exception(result_json["message"] + ": " + str([error["message"] for error in result_json["errors"]]))
+    if(result.status_code != 201):
+        raise Exception(f"{result.status_code}: {result_json['message']}: {str([error['message'] for error in result_json['errors']])}")
+    
+async def delete_user_from_org(
+        username: str,
+        org: str = github_org_name
+) -> None:
+    if username is None:
+        raise Exception("Username cannot be empty")
+    result = await _github_request_delete(f"https://api.github.com/orgs/{org}/memberships/{username}",
+                                          os.environ.get("GITHUB_TOKEN"))
+    # Logging here potentially?
+    if(result.status_code != 204):
+        raise Exception(f"Status code {result.status_code} returned when attempting to delete user {username}")
+    

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -1,9 +1,10 @@
+from constants import guild_id, github_org_name
 from dataclasses import dataclass
-from typing import Any
-
+from json import dumps
+import os
 import requests
-from constants import guild_id
 from requests import Response
+from typing import Any
 
 async def _github_request_get(
         url: str,
@@ -34,3 +35,22 @@ async def _github_request_post(
         data=post_data
     )
     return result
+
+async def add_user_to_org(
+        org: str = github_org_name,
+        uid: str | None = None,
+        email: str | None = None
+) -> None:
+    if uid == None and email == None:
+        raise Exception("uid and username cannot both be empty")
+    
+    # Arbitrarily prefer uid
+    if uid is not None and email is None:
+        res = _github_request_post(f"https://api.github.com/orgs/{org}/invitations", 
+                               os.environ.get("GITHUB_TOKEN"), 
+                               dumps({"invitee_id":uid, "role":"direct_member"}))
+    # Assume at this point both exist, but use email
+    else:
+        res = _github_request_post(f"https://api.github.com/orgs/{org}/invitations", 
+                               os.environ.get("GITHUB_TOKEN"), 
+                               dumps({"email":email, "role":"direct_member"}))

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -1,12 +1,11 @@
+import os
 from dataclasses import dataclass
 from json import dumps
-import os
 from typing import Any
 
 import requests
-from requests import Response
-
 from constants import github_org_name
+from requests import Response
 
 @dataclass
 class GithubUser:

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -102,12 +102,14 @@ async def get_user_by_username(
     """
         Takes in a Github username and returns an instance of GithubUser.
 
-        May return an empty list if no such user was found.
+        May return None if no such user was found.
     """
     result = await _github_request_get(f"https://api.github.com/users/{username}",
                               os.environ.get("GITHUB_TOKEN"))
     result_json = result.json()
-    return [GithubUser(user["login"], user["id"], user["name"]) for user in [result_json]]
+    if result_json["status"] == "404":
+        return None
+    return GithubUser(result_json["login"], result_json["id"], result_json["name"])
 
 async def get_user_by_id(
     uid: str
@@ -115,12 +117,14 @@ async def get_user_by_id(
     """
         Takes in a Github user id and returns an instance of GithubUser.
 
-        May return an empty list if no such user was found.
+        May return None if no such user was found.
     """
     result = await _github_request_get(f"https://api.github.com/user/{uid}",
                               os.environ.get("GITHUB_TOKEN"))
     result_json = result.json()
-    return [GithubUser(user["login"], user["id"], user["name"]) for user in [result_json]]
+    if result_json["status"] == "404":
+        return None
+    return GithubUser(result_json["login"], result_json["id"], result_json["name"])
 
 async def add_user_to_org(
         org: str = github_org_name,

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -109,7 +109,7 @@ async def get_user_by_username(
 
 async def get_user_by_id(
     id: str    
-) -> int:
+) -> GithubUser:
     """
         Takes in a Github user id and returns an instance of GithubUser.
 

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -128,7 +128,7 @@ async def add_user_to_org(
         email: str | None = None
 ) -> None:
     if uid is None and email is None:
-        raise Exception("uid and username cannot both be empty")
+        raise ValueError("uid and username cannot both be empty")
     result = None
     # Arbitrarily prefer uid
     if uid is not None and email is None:

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -108,41 +108,41 @@ async def get_user_by_username(
     return [GithubUser(user["login"], user["id"], user["name"]) for user in [result_json]]
 
 async def get_user_by_id(
-    id: str    
+    uid: str    
 ) -> GithubUser:
     """
         Takes in a Github user id and returns an instance of GithubUser.
 
         May return an empty list if no such user was found.
     """
-    result = await _github_request_get(f"https://api.github.com/user/{id}",
+    result = await _github_request_get(f"https://api.github.com/user/{uid}",
                               os.environ.get("GITHUB_TOKEN"))
     result_json = result.json()
     return [GithubUser(user["login"], user["id"], user["name"]) for user in [result_json]]
-    
+
 async def add_user_to_org(
         org: str = github_org_name,
         uid: str | None = None,
         email: str | None = None
 ) -> None:
-    if uid == None and email == None:
+    if uid is None and email is None:
         raise Exception("uid and username cannot both be empty")
     result = None
     # Arbitrarily prefer uid
     if uid is not None and email is None:
-        result = await _github_request_post(f"https://api.github.com/orgs/{org}/invitations", 
-                               os.environ.get("GITHUB_TOKEN"), 
+        result = await _github_request_post(f"https://api.github.com/orgs/{org}/invitations",
+                               os.environ.get("GITHUB_TOKEN"),
                                dumps({"invitee_id":uid, "role":"direct_member"}))
     # Assume at this point both exist, but use email
     else:
-        result = await _github_request_post(f"https://api.github.com/orgs/{org}/invitations", 
-                               os.environ.get("GITHUB_TOKEN"), 
+        result = await _github_request_post(f"https://api.github.com/orgs/{org}/invitations",
+                               os.environ.get("GITHUB_TOKEN"),
                                dumps({"email":email, "role":"direct_member"}))
     result_json = result.json()
     # Logging here potentially?
     if result.status_code != 201:
-        raise Exception(f"Status code {result.status_code} returned when attempting to add user to org: {result_json['message']}: {str([error['message'] for error in result_json['errors']])}")
-    
+        raise Exception(f"Status code {result.status_code} returned when attempting to add user to org: {result_json['message']}: {[error['message'] for error in result_json['errors']]}")
+
 async def delete_user_from_org(
         username: str,
         org: str = github_org_name
@@ -154,14 +154,13 @@ async def delete_user_from_org(
     # Logging here potentially?
     if result.status_code != 204:
         raise Exception(f"Status code {result.status_code} returned when attempting to delete user {username} from organization {org}")
-    
+  
 async def get_teams(
         org: str = github_org_name
 ) -> list[str]:
     result = await _github_request_get(f"https://api.github.com/orgs/{org}/teams", os.environ.get("GITHUB_TOKEN"))
     json_result = result.json()
     return [GithubTeam(team["id"], team["url"], team["name"], team["slug"]) for team in json_result]
-
 
 async def add_user_to_team(
         username: str,
@@ -175,7 +174,7 @@ async def add_user_to_team(
     # Logging here potentially?
     if result.status_code != 200:
         raise Exception(f"Status code {result.status_code} returned when attempting to add user to team: {result_json['message']}")
-    
+
 async def remove_user_from_team(
         username: str,
         slug: str,

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -36,7 +36,7 @@ async def _github_request_get(
     )
     rate_limit_remaining = int(result.headers["x-ratelimit-remaining"])
     if rate_limit_remaining < 50:
-        raise Exception("Less than 50 api calls remaining before being rate limited, please try again later")
+        return None
 
     return result
 
@@ -56,7 +56,7 @@ async def _github_request_post(
     )
     rate_limit_remaining = int(result.headers["x-ratelimit-remaining"])
     if rate_limit_remaining < 50:
-        raise Exception("Less than 50 api calls remaining before being rate limited, please try again later")
+        return None
 
     return result
 
@@ -73,7 +73,7 @@ async def _github_request_delete(
     )
     rate_limit_remaining = int(result.headers["x-ratelimit-remaining"])
     if rate_limit_remaining < 50:
-        raise Exception("Less than 50 api calls remaining before being rate limited, please try again later")
+        return None
 
     return result
 
@@ -92,7 +92,7 @@ async def _github_request_put(
     )
     rate_limit_remaining = int(result.headers["x-ratelimit-remaining"])
     if rate_limit_remaining < 50:
-        raise Exception("Less than 50 api calls remaining before being rate limited, please try again later")
+        return None
 
     return result
 

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -128,10 +128,12 @@ async def get_user_by_id(
 
 async def add_user_to_org(
         org: str = github_org_name,
-        # We need one of either uid or email. We'll fail if we're provided both.
         uid: str | None = None,
         email: str | None = None
 ) -> None:
+    """
+        Takes one of either uid or email. Fails if provided both.
+    """
     result = None
     if uid is None and email is None:
         raise ValueError("uid and username cannot both be empty")

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -1,10 +1,12 @@
-from constants import github_org_name
 from dataclasses import dataclass
 from json import dumps
 import os
+from typing import Any
+
 import requests
 from requests import Response
-from typing import Any
+
+from constants import github_org_name
 
 @dataclass
 class GithubUser:
@@ -35,7 +37,7 @@ async def _github_request_get(
     rate_limit_remaining = int(result.headers["x-ratelimit-remaining"])
     if rate_limit_remaining < 50:
         raise Exception("Less than 50 api calls remaining before being rate limited, please try again later")
-    
+
     return result
 
 async def _github_request_post(
@@ -108,7 +110,7 @@ async def get_user_by_username(
     return [GithubUser(user["login"], user["id"], user["name"]) for user in [result_json]]
 
 async def get_user_by_id(
-    uid: str    
+    uid: str
 ) -> GithubUser:
     """
         Takes in a Github user id and returns an instance of GithubUser.
@@ -154,7 +156,7 @@ async def delete_user_from_org(
     # Logging here potentially?
     if result.status_code != 204:
         raise Exception(f"Status code {result.status_code} returned when attempting to delete user {username} from organization {org}")
-  
+
 async def get_teams(
         org: str = github_org_name
 ) -> list[str]:

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -12,6 +12,14 @@ class GithubUser:
     id: int
     name: str
 
+@dataclass
+class GithubTeam:
+    id: int
+    url: str
+    name: str
+    # slugs are the space-free special names that github likes to use
+    slug: str
+
 async def _github_request_get(
         url: str,
         token: str
@@ -25,7 +33,7 @@ async def _github_request_get(
         }
     )
     rate_limit_remaining = int(result.headers["x-ratelimit-remaining"])
-    if(rate_limit_remaining) < 50:
+    if rate_limit_remaining < 50:
         raise Exception("Less than 50 api calls remaining before being rate limited, please try again later")
     
     return result
@@ -45,7 +53,7 @@ async def _github_request_post(
         data=post_data
     )
     rate_limit_remaining = int(result.headers["x-ratelimit-remaining"])
-    if(rate_limit_remaining) < 50:
+    if rate_limit_remaining < 50:
         raise Exception("Less than 50 api calls remaining before being rate limited, please try again later")
 
     return result
@@ -62,7 +70,26 @@ async def _github_request_delete(
             "X-GitHub-Api-Version": "2022-11-28"}
     )
     rate_limit_remaining = int(result.headers["x-ratelimit-remaining"])
-    if(rate_limit_remaining) < 50:
+    if rate_limit_remaining < 50:
+        raise Exception("Less than 50 api calls remaining before being rate limited, please try again later")
+
+    return result
+
+async def _github_request_put(
+        url: str,
+        token: str,
+        put_data: Any
+) -> Response:
+    result = requests.put(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28"},
+        data=put_data
+    )
+    rate_limit_remaining = int(result.headers["x-ratelimit-remaining"])
+    if rate_limit_remaining < 50:
         raise Exception("Less than 50 api calls remaining before being rate limited, please try again later")
 
     return result
@@ -113,8 +140,8 @@ async def add_user_to_org(
                                dumps({"email":email, "role":"direct_member"}))
     result_json = result.json()
     # Logging here potentially?
-    if(result.status_code != 201):
-        raise Exception(f"{result.status_code}: {result_json['message']}: {str([error['message'] for error in result_json['errors']])}")
+    if result.status_code != 201:
+        raise Exception(f"Status code {result.status_code} returned when attempting to add user to org: {result_json['message']}: {str([error['message'] for error in result_json['errors']])}")
     
 async def delete_user_from_org(
         username: str,
@@ -125,6 +152,36 @@ async def delete_user_from_org(
     result = await _github_request_delete(f"https://api.github.com/orgs/{org}/memberships/{username}",
                                           os.environ.get("GITHUB_TOKEN"))
     # Logging here potentially?
-    if(result.status_code != 204):
+    if result.status_code != 204:
         raise Exception(f"Status code {result.status_code} returned when attempting to delete user {username}")
+    
+async def get_teams(
+        org: str = github_org_name
+) -> list[str]:
+    result = await _github_request_get(f"https://api.github.com/orgs/{org}/teams", os.environ.get("GITHUB_TOKEN"))
+    json_result = result.json()
+    return [GithubTeam(team["id"], team["url"], team["name"], team["slug"]) for team in json_result]
+
+
+async def add_user_to_team(
+        org: str,
+        username: str,
+        team_id: str | None = None,
+        slug: str | None = None
+) -> None:
+    if team_id is None and slug is None:
+        raise Exception("team_id and slug cannot both be none.")
+    result = None
+    if team_id is not None and slug is None:
+        result = await _github_request_put(f"https://api.github.com/orgs/{org}/team/{team_id}/memberships/{username}",
+                                           os.environ.get("GITHUB_TOKEN"),
+                                           dumps({"role":"member"}))
+    else:
+        result = await _github_request_put(f"https://api.github.com/orgs/{org}/teams/{slug}/memberships/{username}",
+                                           os.environ.get("GITHUB_TOKEN"),
+                                           dumps({"role":"member"}))
+    result_json = result.json()
+    # Logging here potentially?
+    if result.status_code != 200:
+        raise Exception(f"Status code {result.status_code} returned when attempting to add user to team: {result_json['message']}")
     

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -7,6 +7,7 @@ import requests
 from constants import github_org_name
 from requests import Response
 
+
 @dataclass
 class GithubUser:
     username: str

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -168,8 +168,6 @@ async def add_user_to_team(
         slug: str,
         org: str = github_org_name
 ) -> None:
-    if slug is None:
-        raise Exception("Slug cannot be none.")
     result = await _github_request_put(f"https://api.github.com/orgs/{org}/teams/{slug}/memberships/{username}",
                                         os.environ.get("GITHUB_TOKEN"),
                                         dumps({"role":"member"}))
@@ -178,13 +176,11 @@ async def add_user_to_team(
     if result.status_code != 200:
         raise Exception(f"Status code {result.status_code} returned when attempting to add user to team: {result_json['message']}")
     
-    async def remove_user_from_team(
-            username: str,
-            slug: str,
-            org: str = github_org_name
-    ) -> None:
-        if slug is None:
-            raise Exception("Slug cannot be none.")
+async def remove_user_from_team(
+        username: str,
+        slug: str,
+        org: str = github_org_name
+) -> None:
     result = await _github_request_delete(f"https://api.github.com/orgs/{org}/teams/{slug}/memberships/{username}",
                                           os.environ.get("GITHUB_TOKEN"))
     if result.status_code != 204:

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -1,4 +1,4 @@
-from constants import guild_id, github_org_name
+from constants import github_org_name
 from dataclasses import dataclass
 from json import dumps
 import os

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+from constants import guild_id
+from requests import Response
+
+async def _github_request_get(
+        url: str,
+        token: str
+) -> Response:
+    result = requests.get(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28"
+        }
+    )
+    return result
+
+async def _github_request_post(
+        url: str,
+        token: str,
+        post_data: Any
+) -> Response:
+    result = requests.post(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28"
+        },
+        data=post_data
+    )
+    return result

--- a/src/github/github.py
+++ b/src/github/github.py
@@ -25,7 +25,7 @@ class GithubTeam:
 async def _github_request_get(
         url: str,
         token: str
-) -> Response:
+) -> Response | None:
     result = requests.get(
         url,
         headers={
@@ -44,7 +44,7 @@ async def _github_request_post(
         url: str,
         token: str,
         post_data: Any
-) -> Response:
+) -> Response | None:
     result = requests.post(
         url,
         headers={
@@ -63,7 +63,7 @@ async def _github_request_post(
 async def _github_request_delete(
         url: str,
         token: str
-) -> Response:
+) -> Response | None:
     result = requests.delete(
         url,
         headers={
@@ -81,7 +81,7 @@ async def _github_request_put(
         url: str,
         token: str,
         put_data: Any
-) -> Response:
+) -> Response | None:
     result = requests.put(
         url,
         headers={


### PR DESCRIPTION
Closes #20. (Vibes)

The REST API provided by Github has constraints detailed [here](https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28). Realistically the only constraint _we_ care about is `x-ratelimit-remaining` which I've already added a check for. We should probably further discuss _how_ to gracefully handle this as currently I raise an exception when we hit <50 remaining API calls. As noted in #20, all of these functions are handled asynchronously, so I chose to leave a healthy margint o avoid being rate limited.

I added the functionality requested, adding/removing from organizations, adding/removing from teams. This is implemented in a new `github` module.

For testing I've created a new CSSS-Test-Organization, we can talk about transferring ownership of that in person/over call.

Authorization here in the `github` module is token based and administrated through the fine grained personal access token system in Github. As such we can just store it as an environment variable `GITHUB_TOKEN`. 