### PR TITLE
Refactor login flow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,7 @@ line-ending = "lf"
 [tool.ruff.lint]
 select = ["E", "F", "B", "I", "N", "UP", "A", "PTH", "W", "RUF", "C4", "PIE", "Q", "FLY"] # "ANN"
 ignore = ["E501", "F401", "N806"]
+
+[tool.pyright]
+executionEnvironments = [{ root = "src" }]
+typeCheckingMode = "standard"

--- a/src/auth/models.py
+++ b/src/auth/models.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel, Field
+
+
+class LoginBodyModel(BaseModel):
+    service: str = Field(description="Service URL used for SFU's CAS system")
+    ticket: str = Field(description="Ticket return from SFU's CAS system")
+    redirect_url: str | None = Field(None, description="Optional redirect URL")

--- a/src/auth/urls.py
+++ b/src/auth/urls.py
@@ -2,11 +2,10 @@ import base64
 import logging
 import os
 import urllib.parse
-from typing import Literal
 
 import requests  # TODO: make this async
 import xmltodict
-from fastapi import APIRouter, BackgroundTasks, Body, HTTPException, Request, Response
+from fastapi import APIRouter, BackgroundTasks,  HTTPException, Request, Response
 from fastapi.responses import JSONResponse, PlainTextResponse, RedirectResponse
 
 import database

--- a/src/auth/urls.py
+++ b/src/auth/urls.py
@@ -5,7 +5,7 @@ import urllib.parse
 
 import requests  # TODO: make this async
 import xmltodict
-from fastapi import APIRouter, BackgroundTasks,  HTTPException, Request, Response
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, PlainTextResponse, RedirectResponse
 
 import database

--- a/src/auth/urls.py
+++ b/src/auth/urls.py
@@ -12,7 +12,7 @@ from fastapi.responses import JSONResponse, PlainTextResponse, RedirectResponse
 import database
 from auth import crud
 from auth.models import LoginBodyModel
-from constants import IS_PROD
+from constants import DOMAIN, IS_PROD, SAMESITE
 from utils.shared_models import DetailModel
 
 _logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ router = APIRouter(
     "/login",
     description="Create a login session.",
     response_description="Successfully validated with SFU's CAS",
-    response_model=None,
+    response_model=str,
     responses={
         307: { "description": "Successful validation, with redirect" },
         400: { "description": "Origin is missing.", "model": DetailModel },
@@ -87,8 +87,8 @@ async def login_user(
             value=session_id,
             secure=IS_PROD,
             httponly=True,
-            samesite=None if IS_PROD else "lax",
-            domain=".sfucsss.org" if IS_PROD else None
+            samesite=SAMESITE,
+            domain=DOMAIN
         )  # this overwrites any past, possibly invalid, session_id
         return response
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -26,3 +26,7 @@ DISCORD_NICKNAME_LEN = 32
 
 # https://docs.github.com/en/enterprise-server@3.10/admin/identity-and-access-management/iam-configuration-reference/username-considerations-for-external-authentication
 GITHUB_USERNAME_LEN = 39
+
+# COOKIE
+SAMESITE=None if IS_PROD else "lax"
+DOMAIN=".sfucsss.org" if IS_PROD else None

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,7 +3,7 @@ import os
 # TODO(future): replace new.sfucsss.org with sfucsss.org during migration
 # TODO(far-future): branch-specific root IP addresses (e.g., devbranch.sfucsss.org)
 ENV_LOCAL = os.environ.get("LOCAL")
-IS_PROD = False if not ENV_LOCAL or ENV_LOCAL.lower() != "true" else True
+IS_PROD = True if not ENV_LOCAL or ENV_LOCAL.lower() != "true" else False
 GITHUB_ORG_NAME = "CSSS-Test-Organization" if not IS_PROD else "CSSS"
 
 W3_GUILD_ID = "1260652618875797504"

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,8 +2,9 @@ import os
 
 # TODO(future): replace new.sfucsss.org with sfucsss.org during migration
 # TODO(far-future): branch-specific root IP addresses (e.g., devbranch.sfucsss.org)
-FRONTEND_ROOT_URL = "http://localhost:8080" if os.environ.get("LOCAL") == "true" else "https://new.sfucsss.org"
+FRONTEND_ROOT_URL = "http://localhost:8080" if os.environ.get("LOCAL") == "true" else "https://sfucsss.org"
 GITHUB_ORG_NAME = "CSSS-Test-Organization" if os.environ.get("LOCAL") == "true" else "CSSS"
+IS_PROD = os.environ.get("LOCAL") == "false"
 
 W3_GUILD_ID = "1260652618875797504"
 CSSS_GUILD_ID = "228761314644852736"

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,13 +2,13 @@ import os
 
 # TODO(future): replace new.sfucsss.org with sfucsss.org during migration
 # TODO(far-future): branch-specific root IP addresses (e.g., devbranch.sfucsss.org)
-FRONTEND_ROOT_URL = "http://localhost:8080" if os.environ.get("LOCAL") == "true" else "https://sfucsss.org"
-GITHUB_ORG_NAME = "CSSS-Test-Organization" if os.environ.get("LOCAL") == "true" else "CSSS"
-IS_PROD = os.environ.get("LOCAL") == "false"
+ENV_LOCAL = os.environ.get("LOCAL")
+IS_PROD = False if not ENV_LOCAL or ENV_LOCAL.lower() != "true" else True
+GITHUB_ORG_NAME = "CSSS-Test-Organization" if not IS_PROD else "CSSS"
 
 W3_GUILD_ID = "1260652618875797504"
 CSSS_GUILD_ID = "228761314644852736"
-ACTIVE_GUILD_ID = W3_GUILD_ID if os.environ.get("LOCAL") == "true" else CSSS_GUILD_ID
+ACTIVE_GUILD_ID = W3_GUILD_ID if not IS_PROD else CSSS_GUILD_ID
 
 SESSION_ID_LEN = 512
 # technically a max of 8 digits https://www.sfu.ca/computing/about/support/tips/sfu-userid.html
@@ -28,5 +28,5 @@ DISCORD_NICKNAME_LEN = 32
 GITHUB_USERNAME_LEN = 39
 
 # COOKIE
-SAMESITE=None if IS_PROD else "lax"
+SAMESITE="none" if IS_PROD else "lax"
 DOMAIN=".sfucsss.org" if IS_PROD else None

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,7 @@ database.setup_database()
 if not IS_PROD:
     print("Running local environment")
     origins = [
-        "http://localhost:*", # default Angular
+        "http://localhost:4200", # default Angular
         "http://localhost:8080", # for existing applications/sites
     ]
     app = FastAPI(

--- a/src/utils/shared_models.py
+++ b/src/utils/shared_models.py
@@ -3,3 +3,6 @@ from pydantic import BaseModel
 
 class SuccessFailModel(BaseModel):
     success: bool
+
+class DetailModel(BaseModel):
+    detail: str


### PR DESCRIPTION
* closes #88: CORS and redirects using the `origin` requires the host be supplied
* closes #35: Redirect URL/URI should be supplied in full, will look into fragments later
* closes #65: Always send the cookie, since we restrict our API to only certain origins and we currently only ask the backend for API requests since we use a bunch of SPA apps
* closes #91: Request parameters are now stored in the body.
* closes #113 (main focus): Refactored the login flow, to match what was explained in the issue
