### PR TITLE
fix: return 409 when deleting election with nominees

### DIFF
--- a/src/elections/urls.py
+++ b/src/elections/urls.py
@@ -2,6 +2,7 @@ import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
+from sqlalchemy.exc import IntegrityError
 
 import candidates.crud
 import database
@@ -275,15 +276,25 @@ async def update_election(
     "/{election_name}",
     description="Deletes an election from the database. Returns whether the election exists after deletion.",
     response_model=SuccessResponse,
-    responses={401: {"description": "Need to be logged in as an admin.", "model": DetailModel}},
+    responses={
+        401: {"description": "Need to be logged in as an admin.", "model": DetailModel},
+        409: {"description": "Election has associated nominees and cannot be deleted.", "model": DetailModel},
+    },
     operation_id="delete_election",
     dependencies=[Depends(perm_election)],
 )
 async def delete_election(db_session: database.DBSession, election_name: str):
     slugified_name = slugify(election_name)
 
-    await elections.crud.delete_election(db_session, slugified_name)
-    await db_session.commit()
+    try:
+        await elections.crud.delete_election(db_session, slugified_name)
+        await db_session.commit()
+    except IntegrityError:
+        await db_session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Cannot delete election '{slugified_name}' because it has associated nominees. Delete the nominees first.",
+        )
 
     old_election = await elections.crud.get_election(db_session, slugified_name)
     return JSONResponse({"success": old_election is None})


### PR DESCRIPTION
## Problem

When attempting to delete an election that has associated nominees, the foreign key constraint (`election_nominee_application.election_slug` → `election.slug`) causes an `IntegrityError`. This results in an unhandled 500 Internal Server Error.

## Solution

Wrap the delete operation in a try-except block to catch `sqlalchemy.exc.IntegrityError`. On error:
1. Roll back the transaction
2. Return HTTP 409 (Conflict) with a clear error message explaining that nominees must be deleted first

## Changes

- Added `from sqlalchemy.exc import IntegrityError` import
- Wrapped `delete_election` + `commit` in try-except block
- Added 409 response to the endpoint's OpenAPI documentation

## Testing

1. Create an election
2. Add nominees to the election  
3. Try to delete the election → should return 409 with message
4. Delete the nominees first, then delete the election → should succeed

Fixes #131