### PR TITLE
Fix 131 election delete fk conflict 2

### DIFF
--- a/.github/workflows/pytest_unit.yml
+++ b/.github/workflows/pytest_unit.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.*') }}
-          restore-keys: | 
+          restore-keys: |
             ${{ runner.os }}-pip-
 
       - name: Install dependencies

--- a/src/elections/urls.py
+++ b/src/elections/urls.py
@@ -289,12 +289,12 @@ async def delete_election(db_session: database.DBSession, election_name: str):
     try:
         await elections.crud.delete_election(db_session, slugified_name)
         await db_session.commit()
-    except IntegrityError:
+    except IntegrityError as err:
         await db_session.rollback()
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"{election_name} is still referenced by nominee applications.",
-        )
+        ) from err
 
     old_election = await elections.crud.get_election(db_session, slugified_name)
     return JSONResponse({"success": old_election is None})

--- a/src/elections/urls.py
+++ b/src/elections/urls.py
@@ -285,15 +285,15 @@ async def update_election(
 async def delete_election(db_session: database.DBSession, election_name: str):
     slugified_name = slugify(election_name)
 
-    existing_applications = await candidates.crud.get_all_candidates_in_election(db_session, slugified_name)
-    if existing_applications:
+    try:
+        await elections.crud.delete_election(db_session, slugified_name)
+        await db_session.commit()
+    except IntegrityError as error:
+        await db_session.rollback()
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"{election_name} is still referenced by nominee applications.",
         )
-
-    await elections.crud.delete_election(db_session, slugified_name)
-    await db_session.commit()
 
     old_election = await elections.crud.get_election(db_session, slugified_name)
     return JSONResponse({"success": old_election is None})

--- a/src/elections/urls.py
+++ b/src/elections/urls.py
@@ -286,14 +286,14 @@ async def delete_election(db_session: database.DBSession, election_name: str):
     slugified_name = slugify(election_name)
 
     existing_applications = await candidates.crud.get_all_candidates_in_election(db_session, slugified_name)
-    if existing_applications: 
+    if existing_applications:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"{election_name} is still referenced by nominee applications.",
         )
- 
+
     await elections.crud.delete_election(db_session, slugified_name)
     await db_session.commit()
-    
+
     old_election = await elections.crud.get_election(db_session, slugified_name)
     return JSONResponse({"success": old_election is None})

--- a/src/elections/urls.py
+++ b/src/elections/urls.py
@@ -277,7 +277,7 @@ async def update_election(
     response_model=SuccessResponse,
     responses={
         401: {"description": "Need to be logged in as an admin.", "model": DetailModel},
-        409: {"description": "Election is still referenced by nominee applications.", "model": DetailModel}
+        409: {"description": "Election is still referenced by nominee applications.", "model": DetailModel},
     },
     operation_id="delete_election",
     dependencies=[Depends(perm_election)],

--- a/src/elections/urls.py
+++ b/src/elections/urls.py
@@ -275,15 +275,25 @@ async def update_election(
     "/{election_name}",
     description="Deletes an election from the database. Returns whether the election exists after deletion.",
     response_model=SuccessResponse,
-    responses={401: {"description": "Need to be logged in as an admin.", "model": DetailModel}},
+    responses={
+        401: {"description": "Need to be logged in as an admin.", "model": DetailModel},
+        409: {"description": "Election is still referenced by nominee applications.", "model": DetailModel}
+    },
     operation_id="delete_election",
     dependencies=[Depends(perm_election)],
 )
 async def delete_election(db_session: database.DBSession, election_name: str):
     slugified_name = slugify(election_name)
 
+    existing_applications = await candidates.crud.get_all_candidates_in_election(db_session, slugified_name)
+    if existing_applications: 
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"{election_name} is still referenced by nominee applications.",
+        )
+ 
     await elections.crud.delete_election(db_session, slugified_name)
     await db_session.commit()
-
+    
     old_election = await elections.crud.get_election(db_session, slugified_name)
     return JSONResponse({"success": old_election is None})

--- a/src/elections/urls.py
+++ b/src/elections/urls.py
@@ -2,6 +2,7 @@ import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
+from sqlalchemy.exc import IntegrityError
 
 import candidates.crud
 import database
@@ -288,7 +289,7 @@ async def delete_election(db_session: database.DBSession, election_name: str):
     try:
         await elections.crud.delete_election(db_session, slugified_name)
         await db_session.commit()
-    except IntegrityError as error:
+    except IntegrityError:
         await db_session.rollback()
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/tests/wip/test_github.py
+++ b/tests/wip/test_github.py
@@ -4,10 +4,12 @@ import github.internals
 
 # NOTE: must export API key to use github api (mostly...)
 
+
 @pytest.mark.asyncio
 async def test__list_users():
     member_list = await github.internals.list_members()
     print(member_list)
+
 
 @pytest.mark.asyncio
 async def test__get_user_by_name():


### PR DESCRIPTION
Fix: Return 409 on election delete conflict
closes #131 

Issue: Deleting an election with linked nominee applications failed.

Cause: election_nominee_application references election.slug via FK.

Fix: Checked whether a nominee application depends on the election. If yes, raise an 409 error.