### PR TITLE
Moved Translink API under authenticated kiosk routes

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env")
 
     translink_api_key: str | None = None
+    kiosk_secret: str | None = None
 
 
 settings = Settings()

--- a/src/kiosk/auth.py
+++ b/src/kiosk/auth.py
@@ -1,0 +1,28 @@
+import secrets
+from typing import Annotated
+
+from fastapi import HTTPException, Security, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from config import settings
+
+kiosk_bearer = HTTPBearer(auto_error=False)
+KioskCredentials = Annotated[HTTPAuthorizationCredentials | None, Security(kiosk_bearer)]
+
+
+async def require_kiosk_auth(credentials: KioskCredentials) -> None:
+    if settings.kiosk_secret is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication is not configured.",
+        )
+
+    if credentials is None or not secrets.compare_digest(
+        credentials.credentials.encode("utf-8"),
+        settings.kiosk_secret.encode("utf-8"),
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid kiosk token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )

--- a/src/kiosk/urls.py
+++ b/src/kiosk/urls.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, Depends
+
+import translink.urls
+from kiosk.auth import require_kiosk_auth
+
+router = APIRouter(
+    prefix="/kiosk",
+    tags=["kiosk"],
+    dependencies=[Depends(require_kiosk_auth)],
+)
+
+router.include_router(translink.urls.router)

--- a/src/main.py
+++ b/src/main.py
@@ -15,10 +15,10 @@ import database
 import elections.urls
 import event.urls
 import honorary.urls
+import kiosk.urls
 import nominees.urls
 import officers.urls
 import permission.urls
-import translink.urls
 from constants import IS_PROD
 
 logging.basicConfig(level=logging.DEBUG)
@@ -80,7 +80,7 @@ app.include_router(officers.urls.router)
 app.include_router(permission.urls.router)
 app.include_router(event.urls.router)
 app.include_router(honorary.urls.router)
-app.include_router(translink.urls.router)
+app.include_router(kiosk.urls.router)
 
 
 @app.get("/")


### PR DESCRIPTION
Close #155 

Move the TransLink API under a protected kiosk route using Bearer token authentication:
- Added kiosk Bearer auth using `KIOSK_SECRET`
- Created `/kiosk` router with auth applied globally
- Mounted TransLink routes at `/api/kiosk/translink/*`
- Removed public TransLink router mounting from `main.py`