### PR TITLE
fix: Allow legacy officer position strings on list responses

### DIFF
--- a/src/officers/models.py
+++ b/src/officers/models.py
@@ -56,6 +56,8 @@ class OfficerTerm(OfficerTermCreate):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
+    # Historical rows may use position strings outside the current enum.
+    position: OfficerPositionEnum | str  # type: ignore[assignment]
 
     @computed_field
     @property


### PR DESCRIPTION
## Summary

Allow legacy officer position strings on list responses

## Changes

- allow legacy non-enum officer positions on read responses

Fixes #159
