### PR TITLE
Fix officers/all response for legacy positions

### DIFF
--- a/src/officers/constants.py
+++ b/src/officers/constants.py
@@ -46,7 +46,7 @@ class OfficerPosition:
             return _LENGTH_MAP[position]
 
     @staticmethod
-    def to_email(position: OfficerPositionEnum) -> str | None:
+    def to_email(position: str) -> str | None:
         return _EMAIL_MAP.get(position, None)
 
     @staticmethod
@@ -104,7 +104,7 @@ class OfficerPosition:
         ]
 
 
-_EMAIL_MAP = {
+_EMAIL_MAP: dict[str, str] = {
     OfficerPositionEnum.PRESIDENT: "csss-president-current@sfu.ca",
     OfficerPositionEnum.VICE_PRESIDENT: "csss-vp-current@sfu.ca",
     OfficerPositionEnum.TREASURER: "csss-treasurer-current@sfu.ca",

--- a/src/officers/models.py
+++ b/src/officers/models.py
@@ -117,11 +117,7 @@ class Officer(BaseModel):
     @computed_field
     @property
     def csss_email(self) -> str | None:
-        try:
-            position = OfficerPositionEnum(self.position)
-        except ValueError:
-            return None
-        return OfficerPosition.to_email(position)
+        return OfficerPosition.to_email(self.position)
 
     term_id: int
 

--- a/src/officers/models.py
+++ b/src/officers/models.py
@@ -90,7 +90,14 @@ class OfficerBase(BaseModel):
     biography: str | None = None
 
 
-class Officer(OfficerBase):
+class Officer(BaseModel):
+    legal_name: str = Field(..., max_length=OFFICER_LEGAL_NAME_MAX)
+    position: str
+    start_date: date
+    end_date: date | None = None
+    nickname: str | None = None
+    biography: str | None = None
+
     @classmethod
     def public_fields(cls, term: OfficerTermDB, info: OfficerInfoDB) -> Self:
         return cls(
@@ -110,7 +117,11 @@ class Officer(OfficerBase):
     @computed_field
     @property
     def csss_email(self) -> str | None:
-        return OfficerPosition.to_email(self.position)
+        try:
+            position = OfficerPositionEnum(self.position)
+        except ValueError:
+            return None
+        return OfficerPosition.to_email(position)
 
     term_id: int
 


### PR DESCRIPTION
Close #159 

Fix for the /officers/all 500 caused by legacy officer position values such as "elections officer". The Officer response model now treats position as a string, so old database values can be returned without being validated against the current OfficerPositionEnum. Write models still use the enum, so new create/update inputs remain strict.